### PR TITLE
Add python3 package build for EPEL

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+Version 0.2
+-----------
+ * Add GIGABYTE and TERABYTE constants
+
 Version 0.1
 -----------
  * Initial release: pcore has been separated from psys

--- a/python-pcore.spec
+++ b/python-pcore.spec
@@ -1,19 +1,26 @@
-%if 0%{?fedora} > 12 || 0%{?rhel} > 7
+%if 0%{?fedora} > 12 || 0%{?epel} >= 6
 %bcond_without python3
 %else
 %bcond_with python3
 %endif
 
-%if 0%{?rhel} && 0%{?rhel} <= 6
+%if 0%{?epel} >= 7
+%bcond_without python3_other
+%endif
+
+%if 0%{?rhel} <= 6
 %{!?__python2: %global __python2 /usr/bin/python2}
 %{!?python2_sitelib: %global python2_sitelib %(%{__python2} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
 %endif
 %if 0%{with python3}
 %{!?__python3: %global __python3 /usr/bin/python3}
 %{!?python3_sitelib: %global python3_sitelib %(%{__python3} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
+%{!?python3_pkgversion: %global python3_pkgversion 3}
 %endif  # with python3
 
-%define project_name pcore
+%global project_name pcore
+%global project_description %{expand:
+A Python package that provides various core tools}
 
 Name:    python-%project_name
 Version: 0.2
@@ -27,21 +34,28 @@ Source:  http://pypi.python.org/packages/source/p/%project_name/%project_name-%{
 
 BuildArch:     noarch
 BuildRequires: python2-devel python-setuptools
-%if 0%{with python3}
-BuildRequires: python3-devel python3-setuptools
-%endif  # with python3
 
-%description
-A Python package that provides various core tools
+%description %{project_description}
 
 
 %if 0%{with python3}
-%package -n python3-%project_name
-Summary: A Python package that provides various core tools
+%package -n python%{python3_pkgversion}-%project_name
+Summary: %{summary}
+BuildRequires: python%{python3_pkgversion}-devel
+BuildRequires: python%{python3_pkgversion}-setuptools
 
-%description -n python3-%project_name
-A Python package that provides various core tools
+%description -n python%{python3_pkgversion}-%project_name %{project_description}
 %endif  # with python3
+
+
+%if 0%{with python3_other}
+%package -n python%{python3_other_pkgversion}-%project_name
+Summary: %{summary}
+BuildRequires: python%{python3_other_pkgversion}-devel
+BuildRequires: python%{python3_other_pkgversion}-setuptools
+
+%description -n python%{python3_other_pkgversion}-%project_name %{project_description}
+%endif  # with python3_other
 
 
 %prep
@@ -53,6 +67,9 @@ make PYTHON=%{__python2}
 %if 0%{with python3}
 make PYTHON=%{__python3}
 %endif  # with python3
+%if 0%{with python3_other}
+make PYTHON=%{__python3_other}
+%endif  # with python3_other
 
 
 %install
@@ -62,6 +79,9 @@ make PYTHON=%{__python2} INSTALL_FLAGS="-O1 --root '%buildroot'" install
 %if 0%{with python3}
 make PYTHON=%{__python3} INSTALL_FLAGS="-O1 --root '%buildroot'" install
 %endif  # with python3
+%if 0%{with python3_other}
+make PYTHON=%{__python3_other} INSTALL_FLAGS="-O1 --root '%buildroot'" install
+%endif  # with python3_other
 
 
 %files
@@ -71,12 +91,20 @@ make PYTHON=%{__python3} INSTALL_FLAGS="-O1 --root '%buildroot'" install
 %doc ChangeLog README INSTALL
 
 %if 0%{with python3}
-%files -n python3-%project_name
+%files -n python%{python3_pkgversion}-%project_name
 %defattr(-,root,root,-)
 %{python3_sitelib}/pcore
 %{python3_sitelib}/pcore-*.egg-info
 %doc ChangeLog README INSTALL
 %endif  # with python3
+
+%if 0%{with python3_other}
+%files -n python%{python3_other_pkgversion}-%project_name
+%defattr(-,root,root,-)
+%{python3_other_sitelib}/pcore
+%{python3_other_sitelib}/pcore-*.egg-info
+%doc ChangeLog README INSTALL
+%endif  # with python3_other
 
 
 %clean

--- a/python-pcore.spec
+++ b/python-pcore.spec
@@ -24,7 +24,7 @@ A Python package that provides various core tools}
 
 Name:    python-%project_name
 Version: 0.2
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: A Python package that provides various core tools
 
 Group:   Development/Languages
@@ -112,6 +112,9 @@ make PYTHON=%{__python3_other} INSTALL_FLAGS="-O1 --root '%buildroot'" install
 
 
 %changelog
+* Wed Jan 09 2019 Dmitry Konishchev <konishchev@gmail.com> - 0.2-2
+- Add python3 package build for EPEL
+
 * Tue Apr 26 2016 Dmitry Konishchev <konishchev@gmail.com> - 0.2-1
 - Add GIGABYTE and TERABYTE constants
 

--- a/python-pcore.spec
+++ b/python-pcore.spec
@@ -16,7 +16,7 @@
 %define project_name pcore
 
 Name:    python-%project_name
-Version: 0.1
+Version: 0.2
 Release: 1%{?dist}
 Summary: A Python package that provides various core tools
 

--- a/python-pcore.spec
+++ b/python-pcore.spec
@@ -84,5 +84,8 @@ make PYTHON=%{__python3} INSTALL_FLAGS="-O1 --root '%buildroot'" install
 
 
 %changelog
+* Tue Apr 26 2016 Dmitry Konishchev <konishchev@gmail.com> - 0.2-1
+- Add GIGABYTE and TERABYTE constants
+
 * Mon Nov 18 2013 Dmitry Konishchev <konishchev@gmail.com> - 0.1-1
 - New package

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ if __name__ == "__main__":
     with open("README") as readme:
         setup(
             name = "pcore",
-            version = "0.1",
+            version = "0.2",
 
             description = readme.readline().strip(),
             long_description = readme.read().strip() or None,


### PR DESCRIPTION
* В EPEL6/7 появились две ветки `python3.X` версий - `python3` и `python3_other`. Добавлена поддержка сборки таких пакетов, при этом оставлена совместимость со сборкой на чистой `CentOS`, без `EPEL`. Для `Fedora` ничего не изменилось.
  * Гайд по пакетированию - https://fedoraproject.org/wiki/User:Bkabrda/EPEL7_Python3
  * Тестовые билды для актуальных `EPEL/Fedora` - https://copr.fedorainfracloud.org/coprs/miushanov/pyaddons-testing/build/843105/
* Промержен тег `0.2` в `master`. Коммит, на который он поставлен, был без бранча.